### PR TITLE
Update for pg13

### DIFF
--- a/postgres-headers-rs/wrapper.h
+++ b/postgres-headers-rs/wrapper.h
@@ -25,3 +25,4 @@
 #include "utils/rel.h"
 #include "utils/lsyscache.h"
 #include "utils/palloc.h"
+#include "utils/array.h"

--- a/timescale-extension-utils/Cargo.toml
+++ b/timescale-extension-utils/Cargo.toml
@@ -10,3 +10,6 @@ postgres-headers-rs = {version = "*", path = "../postgres-headers-rs"}
 [features]
 default = []
 parse_headers = ["postgres-headers-rs/parse_headers"]
+pg12 = ["parse_headers"]
+pg13 = ["parse_headers"]
+


### PR DESCRIPTION
This does three changes
 1. updates the ereport bindings to the new calling convention.
 2. updates the headers to include utils/array.h
 3. adds version-based feature flags